### PR TITLE
Drop blueprint-compiler

### DIFF
--- a/io.github.tfuxu.floodit.json
+++ b/io.github.tfuxu.floodit.json
@@ -26,20 +26,6 @@
   ],
   "modules" : [
       {
-        "name" : "blueprint-compiler",
-        "buildsystem" : "meson",
-        "cleanup": [
-            "*"
-        ],
-        "sources" : [
-            {
-                "type" : "git",
-                "url" : "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                "tag" : "v0.18.0"
-            }
-        ]
-      },
-      {
           "name" : "floodit",
           "builddir" : true,
           "buildsystem" : "meson",


### PR DESCRIPTION
Blueprint compiler is now part of GNOME runtime 49.